### PR TITLE
Camera libraries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 depthai/
 depthai-python/
 pinsight_install_dependencies.sh
+
+# Ignore depthai experiments
+depthai-experiments/

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@ pinsight_install_dependencies.sh
 
 # Ignore depthai experiments
 depthai-experiments/
+
+# Ignore virual environments
+venv/
+myvenv/

--- a/README.md
+++ b/README.md
@@ -69,4 +69,4 @@ This configuration assumes that the repo was cloned in `/Documents/Projects`. It
 
 This can be enabled via `sudo systemctl enable camera-control`. Likewise, it can be disabled via `sudo systemctl disable camera-control`. After enabling, this service will run after the Pi has sucessfully booted.
 
-**Notes:** The Pi at this point expects displays to connect to, and that this service will not run in headless mode or via X11-forwarding.
+**Note:** The Pi at this point expects displays to connect to; this service will not run in headless mode or via X11-forwarding.

--- a/README.md
+++ b/README.md
@@ -20,13 +20,18 @@ chmod +x pinsight_install_dependencies.sh
 ./pinsight_install_dependencies.sh
 ```
 
-2. To allow the Electron application to serve buttons for the touchscreen, run the following:
+2. To use the additional software needed for the various output modes, clone the DepthAI experiments repository in the project root:
+```
+git clone https://github.com/luxonis/depthai-experiments.git
+```
+
+3. To allow the Electron application to serve buttons for the touchscreen, run the following:
 ```
 sudo apt update
 sudo apt install nodejs npm
 ```
 
-After this, the "frontend" of the application should work in isolation. This can be tested by running `npm start` in the `camera-control/` directory (found in root of repository).
+After this, the "frontend" of the application should work in isolation. This can be tested by running `npm start` in the `camera-control/` directory (found in root of repository). If everything has been cloned in the correct place, `npm start` should run the entire application as a whole.
 
 ## Using a Remote Display
 

--- a/README.md
+++ b/README.md
@@ -74,11 +74,10 @@ Description=Start Camera Control Application
 After=network.target
 
 [Service]
-ExecStart=/bin/bash -c '/usr/bin/npm start >> /home/###/camera-control.log 2>&1'
+ExecStart=/home/###/Documents/Projects/RPi-FSE-Truck/run.sh > /home/###/camera-control.log 2>&1
 WorkingDirectory=/home/###/Documents/Projects/RPi-FSE-Truck/camera-control
 Restart=always
 User=###
-Environment="PATH=/home/###/Documents/Projects/RPi-FSE-Truck/camera-control/node_modules/.bin:/usr/local/bin:/usr/bin:/bin"
 
 [Install]
 WantedBy=multi-user.target

--- a/README.md
+++ b/README.md
@@ -41,3 +41,32 @@ Host truck
 ```
 
 This configuration should work for most, if not all, operating systems on a secondary machine. If using the Pi's built-in HDMI support, this step is not necessary.
+
+## Starting Application From Boot
+
+Usually, SSH-ing into the Pi is not practical, especially when the application is used by general employees. For that reason, it is important to define a startup service for the Electron app (which will later call on more scripts to run the relevant libraries).
+
+From the default folder (`cd ~`), create a new file to tell the Pi what to do on startup through `sudo vim /etc/systemd/system/camera-control.service`. In this file, paste in the following configuration (replace all instances of placeholder `###` with the user name):
+
+```
+[Unit]
+Description=Start Camera Control Application
+After=network.target
+
+[Service]
+ExecStart=/bin/bash -c '/usr/bin/npm start >> /home/###/camera-control.log 2>&1'
+WorkingDirectory=/home/###/Documents/Projects/RPi-FSE-Truck/camera-control
+Restart=always
+User=###
+Environment="PATH=/home/###/Documents/Projects/RPi-FSE-Truck/camera-control/node_modules/.bin:/usr/local/bin:/usr/bin:/bin"
+
+[Install]
+WantedBy=multi-user.target
+
+```
+
+This configuration assumes that the repo was cloned in `/Documents/Projects`. It also assumes that `npm install` has been run in the frontend subfolder (`/Documents/Projects/RPi-FSE-Truck/camera-control`), which should add Electron to the node_modules binaries. If this does not happen, run `npm install electron` after installing all other dependencies.
+
+This can be enabled via `sudo systemctl enable camera-control`. Likewise, it can be disabled via `sudo systemctl disable camera-control`. After enabling, this service will run after the Pi has sucessfully booted.
+
+**Notes:** The Pi at this point expects displays to connect to, and that this service will not run in headless mode or via X11-forwarding.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,22 @@ sudo apt update
 sudo apt install nodejs npm
 ```
 
-After this, the "frontend" of the application should work in isolation. This can be tested by running `npm start` in the `camera-control/` directory (found in root of repository). If everything has been cloned in the correct place, `npm start` should run the entire application as a whole.
+After this, the "frontend" of the application should work in isolation. This can be tested by running `npm start` in the `camera-control/` directory (found in root of repository). If all of the following appropriate steps in this document have been followed, `npm start` should run the entire application as a whole.
+
+4. To correctly install all dependencies, set up a virtual environment and install all required dependencies depending on modes from `depthai-experiments`. These instructions create an environment named `myvenv`.
+```
+python3 -m venv myvenv
+source myvenv/bin/activate
+cd depthai-experiments/gen2-age-gender
+python3 -m pip install -r requirements.txt
+cd ../gen2-emotion-recognition
+python3 -m pip install -r requirements.txt
+cd ../gen2-people-counter
+python3 -m pip install -r requirements.txt
+cd ../..
+```
+
+To leave the venv enter `deactivate`. To re-enter, type `source myvenv/bin/activate`.
 
 ## Using a Remote Display
 
@@ -70,7 +85,7 @@ WantedBy=multi-user.target
 
 ```
 
-This configuration assumes that the repo was cloned in `/Documents/Projects`. It also assumes that `npm install` has been run in the frontend subfolder (`/Documents/Projects/RPi-FSE-Truck/camera-control`), which should add Electron to the node_modules binaries. If this does not happen, run `npm install electron` after installing all other dependencies.
+This configuration assumes that the repo was cloned in `/Documents/Projects` and that all appropriate dependencies have been installed as described above. It also assumes that `npm install` has been run in the frontend subfolder (`/Documents/Projects/RPi-FSE-Truck/camera-control`), which should add Electron to the node_modules binaries. If this does not happen, run `npm install electron` after installing all other dependencies.
 
 This can be enabled via `sudo systemctl enable camera-control`. Likewise, it can be disabled via `sudo systemctl disable camera-control`. After enabling, this service will run after the Pi has sucessfully booted.
 

--- a/camera-control/package-lock.json
+++ b/camera-control/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "camera-control",
       "version": "1.0.0",
-      "license": "ISC",
+      "license": "MIT",
       "devDependencies": {
         "electron": "^33.0.2"
       }

--- a/camera-control/package.json
+++ b/camera-control/package.json
@@ -4,10 +4,15 @@
   "description": "",
   "main": "main.js",
   "scripts": {
-    "start": "electron .",
+    "start": "./node_modules/.bin/electron .",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "keywords": ["electron", "camera", "control", "raspberry-pi"],
+  "keywords": [
+    "electron",
+    "camera",
+    "control",
+    "raspberry-pi"
+  ],
   "author": "",
   "license": "MIT",
   "devDependencies": {

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# This is called by the camera control service
+
+# Activate virtual environment
+source /home/fse/Documents/Projects/RPi-FSE-Truck/myvenv/bin/activate
+
+# Navigate to the working directory and start the application with GPU acceleration disabled
+cd /home/fse/Documents/Projects/RPi-FSE-Truck/camera-control
+npm start -- --disable-gpu


### PR DESCRIPTION
- Add scripting logic to make the Pi enter a virtual environment and run the program from boot
- Added all new configuration information to the README
- TODO:
  - Successfully call each library in `camera-control/main.js` via exec commands
  - Modify configuration logic to ensure the Pi is using the two displays (touchscreen and HDMI-out) correctly